### PR TITLE
Fix: 마이페이지 닉네임 유효성 검사 및 중복 검사 추가 & 기타 수정

### DIFF
--- a/src/main/java/com/project/thisvsthat/myPage/controller/MyPageController.java
+++ b/src/main/java/com/project/thisvsthat/myPage/controller/MyPageController.java
@@ -64,7 +64,7 @@ public class MyPageController {
 
     //정보 수정(닉네임) 처리
     @PatchMapping("")
-    public ResponseEntity<Map<String, Object>> editNickname(@RequestParam String nickname, HttpServletRequest request) {
+    public ResponseEntity<Map<String, Object>> editNickname(@RequestParam(name = "nickname") String nickname, HttpServletRequest request) {
         String token = jwtService.getJwtFromCookies(request);
         if (token == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("success", false, "message", "Unauthorized"));

--- a/src/main/resources/static/css/myPage.css
+++ b/src/main/resources/static/css/myPage.css
@@ -30,6 +30,10 @@
     gap: 10px;
 }
 
+#nickname {
+    padding-left: 5px;  /* input 텍스트 왼쪽 여백 추가 */
+}
+
 .myPage_posts {
     display: flex;
     gap: 10px;
@@ -112,6 +116,10 @@ a {
 
 span {
     font-size: 13px; /* 기본 설정인 14px이 좀 커서 줄였습니당 */
+}
+
+button {
+    cursor: pointer; /* 링크 요소에 커서 포인터 추가했습니당 */
 }
 
 fieldset label input[type='radio'] {

--- a/src/main/resources/static/css/myPage.css
+++ b/src/main/resources/static/css/myPage.css
@@ -19,6 +19,8 @@
 	font-size: var(--font-size-large); /* 16px */
 	line-height: var(--height-large); /* h3 가운데 정렬1 */
 	text-align: center; /* h3 가운데 정렬2 */
+	align-items: center; /* 세로 중앙 정렬 */
+	flex-wrap: wrap; /* 요소들이 한 줄로 넘칠 경우 다음 줄로 넘어가게 */
 }
 
 .myPage_bottom h3 {
@@ -32,6 +34,18 @@
 
 #nickname {
     padding-left: 5px;  /* input 텍스트 왼쪽 여백 추가 */
+}
+
+.message {
+    font-size: var(--font-size-medium); /* 13px */
+}
+
+.message.success {
+    color: var(--font-color-gray); /* 닉네임 수정 성공 시 메시지 컬러 */
+}
+
+.message.error {
+    color: red; /* 닉네임 수정 실패 시 메시지 컬러 */
 }
 
 .myPage_posts {

--- a/src/main/resources/templates/myPage/myPage.html
+++ b/src/main/resources/templates/myPage/myPage.html
@@ -90,7 +90,7 @@
 
         <!-- 투표한 글이 없다면 메시지 출력 -->
         <div th:if="${#lists.isEmpty(votedPosts)}">
-            <p>투표한 게시물이 없습니다</p>
+            <p>투표한 게시물이 없습니다.</p>
         </div>
     </section>
 
@@ -116,7 +116,7 @@
 
             <!-- 내가 올린 글이 없다면 메시지 출력 -->
             <div th:if="${#lists.isEmpty(myPosts)}">
-                <p>올린 게시물이 없습니다</p>
+                <p>올린 게시물이 없습니다.</p>
             </div>
         </div>
     </section>
@@ -126,7 +126,7 @@
             <h2> 4. 참여한 채팅방 </h2>
         </div>
         <div class="myPage_bottom">
-            <p> 참여중인 채팅방이 없습니다</p>
+            <p> 참여 중인 채팅방이 없습니다.</p>
         </div>
     </section>
 
@@ -209,7 +209,7 @@
                     type: "PATCH", // PATCH 요청
                     success: function (response) {
                         if (response.success) {
-                            $message.text("회원 탈퇴가 완료되었습니다.").css("color", "green");
+                            $message.text("회원 탈퇴가 완료되었습니다. 잠시 후 로그아웃됩니다.").css("color", "#858585");
                             $btn.text("탈퇴 완료").prop("disabled", true);
 
                             // 예시: 3초 후 메인 페이지로 이동 (원하는 페이지로 수정 가능)

--- a/src/main/resources/templates/myPage/myPage.html
+++ b/src/main/resources/templates/myPage/myPage.html
@@ -36,7 +36,7 @@
                 <button type="submit" class="btn_large bg_blue">확인</button>
             </form>
             <!-- AJAX 성공 메시지 -->
-            <div id="message"></div>
+            <div id="message" class="message"></div>
         </div>
         <div class="myPage_bottom">
             <h3> 연령대 </h3>
@@ -168,32 +168,84 @@
     });
 
     $(document).ready(function() {
-        $("#nicknameForm").submit(function(event) {
+        const nicknameField = $("#nickname");
+
+        let isNicknameValid = false;
+
+        // 유효성 검사 메시지
+        const validationMessageNickname = "닉네임은 2~20자, 한글/영문/숫자/_/- 만 사용 가능합니다.";
+        const errorMessageNicknameUsed = "이미 사용 중인 닉네임입니다.";
+
+        // 닉네임 유효성 검사 함수
+        function validateNickname(nickname) {
+            const trimmedNickname = nickname.trim(); // 앞뒤 공백 제거
+            const nicknameRegex = /^[a-zA-Z0-9가-힣 _-]+$/;
+            return trimmedNickname.length >= 2 && trimmedNickname.length <= 20 && nicknameRegex.test(trimmedNickname);
+        }
+
+        // 닉네임 중복 검사 (서버에 요청)
+        async function checkNicknameDuplicate(nickname) {
+            try {
+                const encodedNickname = encodeURIComponent(nickname); // 닉네임 인코딩
+                const response = await fetch(`/auth/check-nickname?nickname=${encodedNickname}`);
+                const result = await response.json();
+                return result.duplicate; // 중복이면 true 반환
+            } catch (error) {
+                // console.error("닉네임 중복 검사 실패:", error);
+                return false;
+            }
+        }
+
+        // 닉네임 폼 제출 이벤트
+        $("#nicknameForm").submit(async function(event) {
             event.preventDefault(); // 폼 제출 시 페이지 리로드 방지
 
-            var nickname = $("#nickname").val(); // 사용자 입력값
+            const nickname = nicknameField.val().trim();
 
+            // 닉네임 유효성 검사
+            if (!validateNickname(nickname)) {
+                showMessage(validationMessageNickname, false); // 유효성 실패 메시지 표시
+                nicknameField.focus();
+                return;
+            }
+
+            // 닉네임 중복 검사
+            const isDuplicate = await checkNicknameDuplicate(nickname);
+            if (isDuplicate) {
+                showMessage(errorMessageNicknameUsed, false); // 중복 메시지 표시
+                nicknameField.focus();
+                return;
+            }
+
+            // 닉네임 변경 요청
             $.ajax({
                 url: "/users", // PATCH 매핑에 맞는 URL
                 type: "PATCH", // 요청 방식은 PATCH
-                data: {
-                    nickname: nickname
-                },
+                data: { nickname },
                 success: function(response) {
                     // 요청 성공 시
                     if (response.success) {
-                        $("#message").text("닉네임 변경 성공!").css("color", "green");
-                        $("input[name='nickname']").val(response.updatedNickname); // 수정된 닉네임 반영
+                        showMessage("닉네임 변경이 완료되었습니다.", true); // 성공 메시지 표시
+                        nicknameField.val(response.updatedNickname); // 수정된 닉네임 반영
                     } else {
-                        $("#message").text("닉네임 변경 실패!").css("color", "red");
+                        showMessage("닉네임 변경이 실패하였습니다.", false); // 실패 메시지 표시
                     }
                 },
                 error: function(xhr, status, error) {
                     // 오류 발생 시
-                    $("#message").text("서버 오류가 발생했습니다.").css("color", "red");
+                    showMessage("서버 오류가 발생했습니다.", false); // 서버 오류 메시지 표시
                 }
             });
         });
+
+        // 메시지 표시 함수
+        function showMessage(message, isSuccess) {
+            const messageElement = $("#message");
+            messageElement.text(message); // 메시지 설정
+
+            // 클래스를 초기화하고, success 또는 error 클래스 추가
+            messageElement.removeClass("success error").addClass(isSuccess ? "success" : "error");
+        }
 
         // 탈퇴하기 버튼 클릭 시
         $("#withdrawnBtn").click(function () {
@@ -214,10 +266,10 @@
 
                             // 예시: 3초 후 메인 페이지로 이동 (원하는 페이지로 수정 가능)
                             setTimeout(() => {
-                                window.location.href = "/";
+                                window.location.href = "/logout";
                             }, 3000);
                         } else {
-                            $message.text("회원 탈퇴 실패!").css("color", "red");
+                            $message.text("회원 탈퇴가 실패하였습니다.").css("color", "red");
                             $btn.prop("disabled", false).text("탈퇴하기"); // 버튼 복구
                         }
                     },


### PR DESCRIPTION
## css 및 소소한 수정

1. 닉네임 input 텍스트 왼쪽 여백 추가
    
    ```css
    #nickname {
    	padding-left: 5px; /* input 텍스트 왼쪽 여백 추가 */
    }
    ```
    
2. 링크 요소 cursor:pointer 추가
    
    ```css
    button {
    	cursor: pointer; /* 링크 요소에 커서 포인터 추가했습니당 */
    }
    ```
    
3. 게시물, 채팅방 없을 때 출력되는 메시지
    - 투표한 게시물이 없습니다 → 투표한 게시물이 없습니다.
    - 올린 게시물이 없습니다 → 올린 게시물이 없습니다.
    - 참여중인 채팅방이 없습니다 → 참여 중인 채팅방이 없습니다.
4. 탈퇴 시 화면 출력 메시지
    - 탈퇴 성공
        - 회원 탈퇴가 완료되었습니다. → 회원 탈퇴가 완료되었습니다. 잠시 후 로그아웃됩니다.
        - green → #858585 (※ --font-color-gray)
        
    - 탈퇴 실패
        - 회원 탈퇴 실패! → 회원 탈퇴가 실패하였습니다.

</br>

## 기능: 닉네임 유효성 검사 및 중복 검사 추가

1. 확인 버튼 누를 때 실행
2. `<div id="message" class="message"></div>` 태그에 성공 및 에러 메시지 출력
    
    ```css
    .message {
        font-size: var(--font-size-medium); /* 13px */
    }
    
    .message.success {
        color: var(--font-color-gray); /* 닉네임 수정 성공 시 메시지 컬러 */
    }
    
    .message.error {
        color: red; /* 닉네임 수정 실패 시 메시지 컬러 */
    }
    ```
    
- 성공 시: 닉네임 변경이 완료되었습니다.
- 실패 시: 닉네임 변경이 실패하였습니다.

- 유효성 검사 메시지

    - 닉네임은 2~20자, 한글/영문/숫자/_/- 만 사용 가능합니다.
    - 이미 사용 중인 닉네임입니다.